### PR TITLE
SSL対応

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -6,13 +6,18 @@ RUN apt-get install -y wget
 RUN useradd --create-home --comment "Account for running JIRA" --shell /bin/bash jira
 RUN mkdir -p /opt/atlassian
 
-RUN wget https://www.atlassian.com/software/jira/downloads/binary/atlassian-jira-software-7.1.7-jira-7.1.7.tar.gz \
-    && tar -zxvf atlassian-jira-software-7.1.7-jira-7.1.7.tar.gz -C /opt/atlassian \
-    && rm atlassian-jira-software-7.1.7-jira-7.1.7.tar.gz \
-    && chown -R jira /opt/atlassian/atlassian-jira-software-7.1.7-standalone/ \
-    && chgrp -R jira /opt/atlassian/atlassian-jira-software-7.1.7-standalone/
+ENV JIRA_VERSION 7.1.7
+
+RUN wget https://www.atlassian.com/software/jira/downloads/binary/atlassian-jira-software-${JIRA_VERSION}-jira-${JIRA_VERSION}.tar.gz \
+    && tar -zxvf atlassian-jira-software-${JIRA_VERSION}-jira-${JIRA_VERSION}.tar.gz -C /opt/atlassian \
+    && rm atlassian-jira-software-${JIRA_VERSION}-jira-${JIRA_VERSION}.tar.gz \
+    && chown -R jira /opt/atlassian/atlassian-jira-software-${JIRA_VERSION}-standalone/ \
+    && chgrp -R jira /opt/atlassian/atlassian-jira-software-${JIRA_VERSION}-standalone/
 
 ENV JAVA_HOME /usr/lib/jvm/java-8-oracle
 ENV JIRA_HOME /var/atlassian/application-data/jira
 
-ENTRYPOINT ["/opt/atlassian/atlassian-jira-software-7.1.7-standalone/bin/start-jira.sh", "-fg"]
+COPY entrypoint.sh /sbin/entrypoint.sh
+RUN chmod 755 /sbin/entrypoint.sh
+
+ENTRYPOINT ["/sbin/entrypoint.sh"]

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -1,0 +1,32 @@
+#!/bin/bash
+
+# 環境変数 $SSL がTRUEのときはserver.xmlを編集し、SSL接続待ち受けコネクタを追加する
+# ただし、各SSLパラメータが定義されていないときはコンテナを停止させる
+# 既にSSL接続待ち受けコネクタが追加されているときはserver.xmlを編集せずそのままにする
+if [ "${SSL}" = "TRUE" ]; then
+ isMod=$(grep "SSLCONNECTOR_INSERT" -c /opt/atlassian/atlassian-jira-software-${JIRA_VERSION}-standalone/conf/server.xml)
+
+ if [ "${KEYSTORE_PATH}" = "" ]; then
+  echo "UNDEFINED KEYSTORE_PATH"
+  exit
+ elif [ "${KEYSTORE_PASS}" = "" ]; then
+  echo "UNDEFINED KEYSTORE_PASS"
+  exit
+ elif [ "${KEYALIAS}" = "" ]; then
+  echo "UNDEFINED KEYALIAS"
+  exit
+ elif [ ${isMod} -ne 0 ]; then
+  echo "Already SSL connector is registered"
+ fi
+
+ sed -i 's|</Service>|<Connector port="8443" protocol="org.apache.coyote.http11.Http11Protocol" maxHttpHeaderSize="8192" \
+  SSLEnabled="true" maxThreads="150" minSpareThreads="25" enableLookups="false" disableUploadTimeout="true" acceptCount="100" \
+  scheme="https" secure="true" clientAuth="false" sslProtocol="TLS" useBodyEncodingForURI="true" keyAlias="'${KEYALIAS}'" \
+  keystoreFile="'${KEYSTORE_PATH}'" keystorePass='"${KEYSTORE_PASS}'" keystoreType="JKS"/>\n<!--SSLCONNECTOR_INSERT-->\n </Service>|g' \
+  /opt/atlassian/atlassian-jira-software-${JIRA_VERSION}-standalone/conf/server.xml
+  echo "SSL connector is registered"
+else
+ echo "SSL=FALSE"
+fi
+
+/opt/atlassian/atlassian-jira-software-${JIRA_VERSION}-standalone/bin/start-jira.sh -fg


### PR DESCRIPTION
dockerのENVで下記のSSLパラメータを指定すると、SSL接続待ち受けコネクタを追加するようにしました。
・SSL ： SSL接続をしたいときはTRUE　したくないときはFALSE、もしくは定義なし
・KEYALIAS ： キーのエイリアス
・KEYSTORE_PATH ： キーストアのパス
・KEYSTORE_PASS ： キーストアのパスワード
